### PR TITLE
Fix: Don't pass null to frontend when there is no chapter

### DIFF
--- a/Classes/ViewHelpers/VideoToJsonViewHelper.php
+++ b/Classes/ViewHelpers/VideoToJsonViewHelper.php
@@ -33,11 +33,12 @@ class VideoToJsonViewHelper extends AbstractViewHelper
     ) {
         $settings = $arguments['settings'];
         $movieDir = $settings['movieDir'];
+        $chapters = $settings['chapters'] ?? [];
 
         $result = [
             'chapters' => array_map(function ($item) {
                 return $item['chapter'];
-            }, array_values($settings['chapters'])),
+            }, array_values($chapters)),
 
             'metadata' => [
                 'metadata' => [


### PR DESCRIPTION
When no chapter has been entered in backend, an empty array instead of null should be passed to frontend to avoid an exception.