### PR TITLE
Add more keybindings

### DIFF
--- a/Resources/Private/JavaScript/VideoPlayer/SachsenShakaPlayer.js
+++ b/Resources/Private/JavaScript/VideoPlayer/SachsenShakaPlayer.js
@@ -380,6 +380,14 @@ export default class SachsenShakaPlayer {
     return this.video.readyState >= 2;
   }
 
+  get showCaptions() {
+    return this.player.isTextTrackVisible()
+  }
+
+  set showCaptions(value) {
+    this.player.setTextTrackVisibility(value);
+  }
+
   /**
    * Volume in range [0, 1]. Out-of-bounds values are clamped when set.
    *

--- a/Resources/Private/JavaScript/VideoPlayerApp/Environment.js
+++ b/Resources/Private/JavaScript/VideoPlayerApp/Environment.js
@@ -98,17 +98,23 @@ export default class Environment {
    *
    * @param {string} key
    * @param {Record<string, string | number>} values
+   * @param {(() => string) | undefined} fallback (Optional) Function to
+   * generate fallback string when {@link key} is not fonud.
    * @returns {string}
    */
-  t(key, values = {}) {
+  t(key, values = {}, fallback = undefined) {
     let phrase = this.lang.phrasesCompiled[key];
 
     if (phrase === undefined) {
       const phraseStr = this.lang.phrasesInput[key];
 
       if (phraseStr === undefined) {
-        console.error(`Warning: Translation key '${key}' not defined.`);
-        return key;
+        if (typeof fallback === 'function') {
+          return fallback();
+        } else {
+          console.error(`Warning: Translation key '${key}' not defined, fallback not provided.`);
+          return key;
+        }
       }
 
       phrase

--- a/Resources/Private/JavaScript/VideoPlayerApp/Environment.test.js
+++ b/Resources/Private/JavaScript/VideoPlayerApp/Environment.test.js
@@ -28,18 +28,24 @@ describe('supportsCanvasExport', () => {
 });
 
 describe('setLang / t', () => {
-  test('basic', () => {
-    const env = new Environment();
-    env.setLang({
-      locale: 'en_US',
-      twoLetterIsoCode: 'en',
-      phrases: {
-        'apple': "{count, plural, =0 {no apple} one {one apple} other {# apples}}",
-      },
-    });
+  const env = new Environment();
+  env.setLang({
+    locale: 'en_US',
+    twoLetterIsoCode: 'en',
+    phrases: {
+      'apple': "{count, plural, =0 {no apple} one {one apple} other {# apples}}",
+      'test': "Test",
+    },
+  });
 
+  test('basic', () => {
     expect(env.t('apple', { count: 0 })).toBe("no apple");
     expect(env.t('apple', { count: 1 })).toBe("one apple");
     expect(env.t('apple', { count: 3 })).toBe("3 apples");
+  });
+
+  test('uses fallback for translation', () => {
+    expect(env.t('test', {}, () => 'fallback')).toBe("Test");
+    expect(env.t('not.existent', {}, () => 'fallback')).toBe("fallback");
   });
 });

--- a/Resources/Private/JavaScript/VideoPlayerApp/SxndPlayerApp.js
+++ b/Resources/Private/JavaScript/VideoPlayerApp/SxndPlayerApp.js
@@ -177,6 +177,9 @@ export default class SxndPlayerApp {
       'playback.volume.dec': () => {
         this.sxndPlayer.volume = this.sxndPlayer.volume - this.constants.volumeStep;
       },
+      'playback.captions.toggle': () => {
+        this.sxndPlayer.showCaptions = !this.sxndPlayer.showCaptions;
+      },
       'navigate.rewind': () => {
         this.sxndPlayer.skipSeconds(-this.constants.seekStep);
       },

--- a/Resources/Private/JavaScript/VideoPlayerApp/SxndPlayerApp.js
+++ b/Resources/Private/JavaScript/VideoPlayerApp/SxndPlayerApp.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { e } from '../lib/util';
-import { Modifier, modifiersFromEvent } from '../lib/Keyboard';
+import { Keybindings$find } from '../lib/Keyboard';
 import {
   Chapters,
   ControlPanelButton,
@@ -367,21 +367,14 @@ export default class SxndPlayerApp {
   onKeyDown(e) {
     let stopPropagation = true;
 
-    const mod = modifiersFromEvent(e);
     const curKbScope = this.getKeyboardScope();
+    const result = Keybindings$find(this.keybindings, e, curKbScope);
 
-    const keybinding = this.keybindings.find(kb => (
-      typeof this.actions[kb.action] === 'function'
-      // Ignore casing, e.g. for `S` vs. `Shift + S`.
-      && kb.key.toLowerCase() === e.key.toLowerCase()
-      && (kb.repeat == null || kb.repeat === e.repeat)
-      && (kb.scope == null || kb.scope === curKbScope)
-      && Modifier[kb.mod ?? 'None'] === mod
-    ));
+    if (result) {
+      const { keybinding, keyIndex } = result;
 
-    if (keybinding) {
       e.preventDefault();
-      this.actions[keybinding.action]();
+      this.actions[keybinding.action]?.(keybinding, keyIndex);
 
       if (keybinding.propagate === true) {
         stopPropagation = false;

--- a/Resources/Private/JavaScript/VideoPlayerApp/SxndPlayerApp.js
+++ b/Resources/Private/JavaScript/VideoPlayerApp/SxndPlayerApp.js
@@ -204,6 +204,19 @@ export default class SxndPlayerApp {
       'navigate.frame.next': () => {
         this.sxndPlayer.getVifa()?.seekForward(1);
       },
+      'navigate.position.percental': (
+        /** @type {Keybinding<any, any>} */ kb,
+        /** @type {number} */ keyIndex
+      ) => {
+        if (0 <= keyIndex && keyIndex < kb.keys.length) {
+          // Implies kb.keys.length > 0
+
+          const relative = keyIndex / kb.keys.length;
+          const absolute = relative * this.sxndPlayer.getVideo().duration;
+
+          this.sxndPlayer.seekTo(absolute);
+        }
+      },
     };
 
     this.modals.on('closed', this.handlers.onCloseModal);

--- a/Resources/Private/JavaScript/VideoPlayerApp/VideoPlayerApp.d.ts
+++ b/Resources/Private/JavaScript/VideoPlayerApp/VideoPlayerApp.d.ts
@@ -50,9 +50,15 @@ type Keybinding<ScopeT extends string, ActionT extends string> = {
   mod?: "None" | "CtrlMeta" | "Shift" | "Alt";
 
   /**
-   * Name of the key to be bound.
+   * Names of the key or keys to be bound.
+   *
+   * Using multiple keys signifies that all of those inherently trigger the
+   * same action. The event handler may use the list of keys to parameterize
+   * its action.
+   *
+   * For creating an alias, consider adding a full keybinding entry instead.
    */
-  key: string;
+  keys: KeyboardEvent['key'][];
 
   /**
    * Boolean to indicate that the keypress must / must not be repeated;

--- a/Resources/Private/JavaScript/VideoPlayerApp/keybindings.json
+++ b/Resources/Private/JavaScript/VideoPlayerApp/keybindings.json
@@ -1,33 +1,33 @@
 [
 	{
-		"key": "Escape",
+		"keys": ["Escape"],
 		"action": "cancel",
 		"kind": "other",
 		"order": 100
 	},
 	{
-		"key": "F1",
+		"keys": ["F1"],
 		"repeat": false,
 		"action": "modal.help.toggle",
 		"kind": "other",
 		"order": 99
 	},
 	{
-		"key": "b",
+		"keys": ["b"],
 		"scope": "player",
 		"action": "modal.bookmark.open",
 		"kind": "other",
 		"order": 30
 	},
 	{
-		"key": "s",
+		"keys": ["s"],
 		"scope": "player",
 		"action": "modal.screenshot.open",
 		"kind": "other",
 		"order": 31
 	},
 	{
-		"key": "s",
+		"keys": ["s"],
 		"mod": "Shift",
 		"scope": "player",
 		"action": "modal.screenshot.snap",
@@ -35,7 +35,7 @@
 		"order": 32
 	},
 	{
-		"key": "f",
+		"keys": ["f"],
 		"repeat": false,
 		"scope": "player",
 		"action": "fullscreen.toggle",
@@ -43,7 +43,7 @@
 		"order": 20
 	},
 	{
-		"key": "t",
+		"keys": ["t"],
 		"repeat": false,
 		"scope": "player",
 		"action": "theater.toggle",
@@ -51,7 +51,7 @@
 		"order": 21
 	},
 	{
-		"key": " ",
+		"keys": [" "],
 		"repeat": false,
 		"scope": "player",
 		"action": "playback.toggle",
@@ -59,7 +59,7 @@
 		"order": 0
 	},
 	{
-		"key": "m",
+		"keys": ["m"],
 		"repeat": false,
 		"scope": "player",
 		"action": "playback.volume.mute.toggle",
@@ -67,21 +67,21 @@
 		"order": 12
 	},
 	{
-		"key": "ArrowUp",
+		"keys": ["ArrowUp"],
 		"scope": "player",
 		"action": "playback.volume.inc",
 		"kind": "player",
 		"order": 10
 	},
 	{
-		"key": "ArrowDown",
+		"keys": ["ArrowDown"],
 		"scope": "player",
 		"action": "playback.volume.dec",
 		"kind": "player",
 		"order": 11
 	},
 	{
-		"key": "c",
+		"keys": ["c"],
 		"repeat": false,
 		"scope": "player",
 		"action": "playback.captions.toggle",
@@ -89,7 +89,7 @@
 		"order": 13
 	},
 	{
-		"key": "ArrowLeft",
+		"keys": ["ArrowLeft"],
 		"repeat": false,
 		"scope": "player",
 		"action": "navigate.rewind",
@@ -97,7 +97,7 @@
 		"order": 0
 	},
 	{
-		"key": "ArrowRight",
+		"keys": ["ArrowRight"],
 		"repeat": false,
 		"scope": "player",
 		"action": "navigate.seek",
@@ -105,7 +105,7 @@
 		"order": 1
 	},
 	{
-		"key": "ArrowLeft",
+		"keys": ["ArrowLeft"],
 		"repeat": true,
 		"scope": "player",
 		"action": "navigate.continuous-rewind",
@@ -113,7 +113,7 @@
 		"order": 2
 	},
 	{
-		"key": "ArrowRight",
+		"keys": ["ArrowRight"],
 		"repeat": true,
 		"scope": "player",
 		"action": "navigate.continuous-seek",
@@ -122,7 +122,7 @@
 	},
 	{
 		"mod": "CtrlMeta",
-		"key": "ArrowLeft",
+		"keys": ["ArrowLeft"],
 		"scope": "player",
 		"action": "navigate.chapter.prev",
 		"kind": "navigate",
@@ -130,7 +130,7 @@
 	},
 	{
 		"mod": "CtrlMeta",
-		"key": "ArrowRight",
+		"keys": ["ArrowRight"],
 		"scope": "player",
 		"action": "navigate.chapter.next",
 		"kind": "navigate",
@@ -138,7 +138,7 @@
 	},
 	{
 		"mod": "Shift",
-		"key": "ArrowLeft",
+		"keys": ["ArrowLeft"],
 		"scope": "player",
 		"action": "navigate.frame.prev",
 		"kind": "navigate",
@@ -146,21 +146,21 @@
 	},
 	{
 		"mod": "Shift",
-		"key": "ArrowRight",
+		"keys": ["ArrowRight"],
 		"scope": "player",
 		"action": "navigate.frame.next",
 		"kind": "navigate",
 		"order": 21
 	},
 	{
-		"key": ",",
+		"keys": [","],
 		"scope": "player",
 		"action": "navigate.frame.prev",
 		"kind": "navigate",
 		"order": 20
 	},
 	{
-		"key": ".",
+		"keys": ["."],
 		"scope": "player",
 		"action": "navigate.frame.next",
 		"kind": "navigate",

--- a/Resources/Private/JavaScript/VideoPlayerApp/keybindings.json
+++ b/Resources/Private/JavaScript/VideoPlayerApp/keybindings.json
@@ -81,6 +81,14 @@
 		"order": 11
 	},
 	{
+		"key": "c",
+		"repeat": false,
+		"scope": "player",
+		"action": "playback.captions.toggle",
+		"kind": "player",
+		"order": 13
+	},
+	{
 		"key": "ArrowLeft",
 		"repeat": false,
 		"scope": "player",

--- a/Resources/Private/JavaScript/VideoPlayerApp/keybindings.json
+++ b/Resources/Private/JavaScript/VideoPlayerApp/keybindings.json
@@ -137,6 +137,13 @@
 		"order": 11
 	},
 	{
+		"keys": ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
+		"scope": "player",
+		"action": "navigate.position.percental",
+		"kind": "navigate",
+		"order": 11
+	},
+	{
 		"mod": "Shift",
 		"keys": ["ArrowLeft"],
 		"scope": "player",

--- a/Resources/Private/JavaScript/VideoPlayerApp/keybindings.json
+++ b/Resources/Private/JavaScript/VideoPlayerApp/keybindings.json
@@ -7,6 +7,7 @@
 	},
 	{
 		"key": "F1",
+		"repeat": false,
 		"action": "modal.help.toggle",
 		"kind": "other",
 		"order": 99

--- a/Resources/Private/JavaScript/VideoPlayerApp/keybindings.test.js
+++ b/Resources/Private/JavaScript/VideoPlayerApp/keybindings.test.js
@@ -1,0 +1,34 @@
+// @ts-check
+
+import { describe, expect, test } from '@jest/globals';
+import Environment from './Environment';
+import { getKeybindingText } from './lib/trans';
+
+import keybindings from './keybindings.json';
+
+describe('format translated key description', () => {
+  const env = new Environment();
+  env.setLang({
+    locale: 'en_US',
+    twoLetterIsoCode: 'en',
+    phrases: {
+      'key.generic': "Key {key}",
+      'key.generic.mod': "{key}",
+      'key.mod.Shift': "Shift",
+      'key.unto': " to ",
+      'key.unto.mod': "-",
+    },
+  });
+
+  test('key S for opening screenshot modal', () => {
+    const kb = keybindings.find(kb => kb.action === 'modal.screenshot.open');
+    const text = getKeybindingText(env, /** @type {any} */(kb));
+    expect(text).toBe("Key S");
+  });
+
+  test('shift S for taking screenshot', () => {
+    const kb = keybindings.find(kb => kb.action === 'modal.screenshot.snap');
+    const text = getKeybindingText(env, /** @type {any} */(kb));
+    expect(text).toBe("Shift + S");
+  });
+});

--- a/Resources/Private/JavaScript/VideoPlayerApp/keybindings.test.js
+++ b/Resources/Private/JavaScript/VideoPlayerApp/keybindings.test.js
@@ -31,4 +31,10 @@ describe('format translated key description', () => {
     const text = getKeybindingText(env, /** @type {any} */(kb));
     expect(text).toBe("Shift + S");
   });
+
+  test('numeric keys for jumping to position', () => {
+    const kb = keybindings.find(kb => kb.action === 'navigate.position.percental');
+    const text = getKeybindingText(env, /** @type {any} */(kb));
+    expect(text).toBe("Key 0 to Key 9");
+  });
 });

--- a/Resources/Private/JavaScript/VideoPlayerApp/lib/trans.js
+++ b/Resources/Private/JavaScript/VideoPlayerApp/lib/trans.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { Keybinding$splitKeyRanges } from '../../lib/Keyboard';
 import { e } from '../../lib/util';
 
 /**
@@ -30,9 +31,25 @@ export function listKeybindingsDisj(env, kbs) {
  * @returns {string}
  */
 export function getKeybindingText(env, kb) {
+  const keyRanges = Keybinding$splitKeyRanges(kb.keys);
+  const rangeTexts = [];
+  const app = kb.mod || keyRanges.length > 1 ? '.mod' : '';
+
+  for (const range of keyRanges) {
+    const beginText = env.t(`key.${range.begin}${app}`);
+
+    if (range.begin === range.end) {
+      rangeTexts.push(beginText);
+    } else {
+      const endText = env.t(`key.${range.end}${app}`);
+
+      rangeTexts.push(`${beginText}${env.t(`key.unto${app}`)}${endText}`);
+    }
+  }
+
   let text = kb.mod
-    ? env.t(`key.mod.${kb.mod}`) + " + " + env.t(`key.${kb.key}.mod`)
-    : env.t(`key.${kb.key}`);
+    ? (env.t(`key.mod.${kb.mod}`) + " + " + rangeTexts.join("/"))
+    : rangeTexts.join(" / ");
 
   if (kb.repeat) {
     text = env.t('key.repeat', { key: text });

--- a/Resources/Private/JavaScript/VideoPlayerApp/lib/trans.js
+++ b/Resources/Private/JavaScript/VideoPlayerApp/lib/trans.js
@@ -24,6 +24,20 @@ export function listKeybindingsDisj(env, kbs) {
 }
 
 /**
+ * Returns a translated string describing key {@link key}.
+ *
+ * @param {Translator} env
+ * @param {KeyboardEvent['key']} key
+ * @param {boolean} mod
+ * @returns {string}
+ */
+export function getKeyText(env, key, mod) {
+  const app = mod ? '.mod' : '';
+  return env.t(`key.${key}${app}`, {},
+    () => env.t(`key.generic${app}`, { key: key.toUpperCase() }));
+}
+
+/**
  * Returns a translated string describing keybinding {@link kb}.
  *
  * @param {Translator} env
@@ -33,17 +47,18 @@ export function listKeybindingsDisj(env, kbs) {
 export function getKeybindingText(env, kb) {
   const keyRanges = Keybinding$splitKeyRanges(kb.keys);
   const rangeTexts = [];
-  const app = kb.mod || keyRanges.length > 1 ? '.mod' : '';
+  const mod = kb.mod !== undefined || keyRanges.length > 1;
+  const untoText = env.t(`key.unto${mod ? '.mod' : ''}`);
 
   for (const range of keyRanges) {
-    const beginText = env.t(`key.${range.begin}${app}`);
+    const beginText = getKeyText(env, range.begin, mod);
 
     if (range.begin === range.end) {
       rangeTexts.push(beginText);
     } else {
-      const endText = env.t(`key.${range.end}${app}`);
+      const endText = getKeyText(env, range.end, mod);
 
-      rangeTexts.push(`${beginText}${env.t(`key.unto${app}`)}${endText}`);
+      rangeTexts.push(`${beginText}${untoText}${endText}`);
     }
   }
 

--- a/Resources/Private/JavaScript/lib/Keyboard.test.js
+++ b/Resources/Private/JavaScript/lib/Keyboard.test.js
@@ -1,17 +1,36 @@
 // @ts-check
 
-import { expect, test } from '@jest/globals';
-import { modifiersFromEvent, Modifier } from './Keyboard';
+import { describe, expect, test } from '@jest/globals';
+import { modifiersFromEvent, Modifier, Keybinding$splitKeyRanges } from './Keyboard';
 
-test('can get modifiers from event', () => {
-  // This is mostly for typing
-  const mfe = (/** @type {any} */ e) => modifiersFromEvent(e);
+describe('modifiersFromEvent', () => {
+  test('basic', () => {
+    // This is mostly for typing
+    const mfe = (/** @type {any} */ e) => modifiersFromEvent(e);
 
-  expect(mfe({ ctrlKey: true })).toBe(Modifier.CtrlMeta);
-  expect(mfe({ metaKey: true })).toBe(Modifier.CtrlMeta);
-  expect(mfe({ ctrlKey: true, metaKey: true })).toBe(Modifier.CtrlMeta);
-  expect(mfe({ shiftKey: true })).toBe(Modifier.Shift);
-  expect(mfe({ altKey: true })).toBe(Modifier.Alt);
-  expect(mfe({ shiftKey: true, altKey: true }))
-    .toBe(Modifier.Shift | Modifier.Alt);
+    expect(mfe({ ctrlKey: true })).toBe(Modifier.CtrlMeta);
+    expect(mfe({ metaKey: true })).toBe(Modifier.CtrlMeta);
+    expect(mfe({ ctrlKey: true, metaKey: true })).toBe(Modifier.CtrlMeta);
+    expect(mfe({ shiftKey: true })).toBe(Modifier.Shift);
+    expect(mfe({ altKey: true })).toBe(Modifier.Alt);
+    expect(mfe({ shiftKey: true, altKey: true }))
+      .toBe(Modifier.Shift | Modifier.Alt);
+  });
+});
+
+describe('Keybinding$splitKeyRanges', () => {
+  test('no keys', () => {
+    const ranges = Keybinding$splitKeyRanges([]);
+    expect(ranges).toEqual([]);
+  });
+
+  test('basic', () => {
+    const ranges = Keybinding$splitKeyRanges(['0', '1', '2', '4', '7', '8']);
+
+    expect(ranges).toEqual([
+      { begin: '0', end: '2' },
+      { begin: '4', end: '4' },
+      { begin: '7', end: '8' },
+    ]);
+  });
 });

--- a/Resources/Private/JavaScript/lib/lib.d.ts
+++ b/Resources/Private/JavaScript/lib/lib.d.ts
@@ -72,5 +72,5 @@ interface Translator {
   /**
    * Get translated phrase of given {@link key}.
    */
-  t(key: string, values?: Record<string, string | number>): string;
+  t(key: string, values?: Record<string, string | number>, fallback?: () => string): string;
 }

--- a/Resources/Private/Language/de.locallang_video.xlf
+++ b/Resources/Private/Language/de.locallang_video.xlf
@@ -73,6 +73,10 @@
 				<source><![CDATA[Fast-forward ({trickPlayFactor}x)]]></source>
 				<target><![CDATA[Vorspulen ({trickPlayFactor}x)]]></target>
 			</trans-unit>
+			<trans-unit id="action.playback.captions.toggle" approved="yes">
+				<source><![CDATA[Toggle captions]]></source>
+				<target><![CDATA[Untertitel an / aus]]></target>
+			</trans-unit>
 			<trans-unit id="action.playback.toggle" approved="yes">
 				<source><![CDATA[Play / Pause]]></source>
 				<target><![CDATA[Abspielen / Pausieren]]></target>
@@ -192,6 +196,10 @@
 			<trans-unit id="key.b" approved="yes">
 				<source><![CDATA[Key B]]></source>
 				<target><![CDATA[Taste B]]></target>
+			</trans-unit>
+			<trans-unit id="key.c" approved="yes">
+				<source><![CDATA[Key C]]></source>
+				<target><![CDATA[Taste C]]></target>
 			</trans-unit>
 			<trans-unit id="key.f" approved="yes">
 				<source><![CDATA[Key F]]></source>

--- a/Resources/Private/Language/de.locallang_video.xlf
+++ b/Resources/Private/Language/de.locallang_video.xlf
@@ -73,6 +73,10 @@
 				<source><![CDATA[Fast-forward ({trickPlayFactor}x)]]></source>
 				<target><![CDATA[Vorspulen ({trickPlayFactor}x)]]></target>
 			</trans-unit>
+			<trans-unit id="action.navigate.position.percental" approved="yes">
+				<source><![CDATA[Jump to position (%)]]></source>
+				<target><![CDATA[Zu Position springen (%)]]></target>
+			</trans-unit>
 			<trans-unit id="action.playback.captions.toggle" approved="yes">
 				<source><![CDATA[Toggle captions]]></source>
 				<target><![CDATA[Untertitel an / aus]]></target>

--- a/Resources/Private/Language/de.locallang_video.xlf
+++ b/Resources/Private/Language/de.locallang_video.xlf
@@ -233,6 +233,14 @@
 				<source><![CDATA[S]]></source>
 				<target><![CDATA[S]]></target>
 			</trans-unit>
+			<trans-unit id="key.unto" approved="yes">
+				<source><![CDATA[ to ]]></source>
+				<target><![CDATA[ bis ]]></target>
+			</trans-unit>
+			<trans-unit id="key.unto.mod" approved="yes">
+				<source><![CDATA[-]]></source>
+				<target><![CDATA[-]]></target>
+			</trans-unit>
 			<trans-unit id="modal.bookmark.copy-link" approved="yes">
 				<source><![CDATA[Copy Link]]></source>
 				<target><![CDATA[Link kopieren]]></target>

--- a/Resources/Private/Language/de.locallang_video.xlf
+++ b/Resources/Private/Language/de.locallang_video.xlf
@@ -149,6 +149,14 @@
 				<source><![CDATA[This video cannot be played back in your browser.]]></source>
 				<target><![CDATA[Dieses Video kann in Ihrem Browser nicht wiedergegeben werden.]]></target>
 			</trans-unit>
+			<trans-unit id="key.generic">
+				<source><![CDATA[Key {key}]]></source>
+				<target><![CDATA[Taste {key}]]></target>
+			</trans-unit>
+			<trans-unit id="key.generic.mod">
+				<source><![CDATA[{key}]]></source>
+				<target><![CDATA[{key}]]></target>
+			</trans-unit>
 			<trans-unit id="key. " approved="yes">
 				<source><![CDATA[Space Bar]]></source>
 				<target><![CDATA[Leertaste]]></target>
@@ -193,26 +201,6 @@
 				<source><![CDATA[F1]]></source>
 				<target><![CDATA[F1]]></target>
 			</trans-unit>
-			<trans-unit id="key.b" approved="yes">
-				<source><![CDATA[Key B]]></source>
-				<target><![CDATA[Taste B]]></target>
-			</trans-unit>
-			<trans-unit id="key.c" approved="yes">
-				<source><![CDATA[Key C]]></source>
-				<target><![CDATA[Taste C]]></target>
-			</trans-unit>
-			<trans-unit id="key.f" approved="yes">
-				<source><![CDATA[Key F]]></source>
-				<target><![CDATA[Taste F]]></target>
-			</trans-unit>
-			<trans-unit id="key.m" approved="yes">
-				<source><![CDATA[Key M]]></source>
-				<target><![CDATA[Taste M]]></target>
-			</trans-unit>
-			<trans-unit id="key.t" approved="yes">
-				<source><![CDATA[Key T]]></source>
-				<target><![CDATA[Taste T]]></target>
-			</trans-unit>
 			<trans-unit id="key.mod.CtrlMeta" approved="yes">
 				<source><![CDATA[Ctrl]]></source>
 				<target><![CDATA[Strg]]></target>
@@ -224,14 +212,6 @@
 			<trans-unit id="key.repeat" approved="yes">
 				<source><![CDATA[{key} (repeat)]]></source>
 				<target><![CDATA[{key} (halten)]]></target>
-			</trans-unit>
-			<trans-unit id="key.s" approved="yes">
-				<source><![CDATA[Key S]]></source>
-				<target><![CDATA[Taste S]]></target>
-			</trans-unit>
-			<trans-unit id="key.s.mod" approved="yes">
-				<source><![CDATA[S]]></source>
-				<target><![CDATA[S]]></target>
 			</trans-unit>
 			<trans-unit id="key.unto" approved="yes">
 				<source><![CDATA[ to ]]></source>

--- a/Resources/Private/Language/locallang_video.xlf
+++ b/Resources/Private/Language/locallang_video.xlf
@@ -113,6 +113,12 @@
 			<trans-unit id="error.playback-not-supported">
 				<source><![CDATA[This video cannot be played back in your browser.]]></source>
 			</trans-unit>
+			<trans-unit id="key.generic">
+				<source><![CDATA[Key {key}]]></source>
+			</trans-unit>
+			<trans-unit id="key.generic.mod">
+				<source><![CDATA[{key}]]></source>
+			</trans-unit>
 			<trans-unit id="key. ">
 				<source><![CDATA[Space Bar]]></source>
 			</trans-unit>
@@ -146,21 +152,6 @@
 			<trans-unit id="key.F1">
 				<source><![CDATA[F1]]></source>
 			</trans-unit>
-			<trans-unit id="key.b">
-				<source><![CDATA[Key B]]></source>
-			</trans-unit>
-			<trans-unit id="key.c">
-				<source><![CDATA[Key C]]></source>
-			</trans-unit>
-			<trans-unit id="key.f">
-				<source><![CDATA[Key F]]></source>
-			</trans-unit>
-			<trans-unit id="key.m">
-				<source><![CDATA[Key M]]></source>
-			</trans-unit>
-			<trans-unit id="key.t">
-				<source><![CDATA[Key T]]></source>
-			</trans-unit>
 			<trans-unit id="key.mod.CtrlMeta">
 				<source><![CDATA[Ctrl]]></source>
 			</trans-unit>
@@ -169,9 +160,6 @@
 			</trans-unit>
 			<trans-unit id="key.repeat">
 				<source><![CDATA[{key} (repeat)]]></source>
-			</trans-unit>
-			<trans-unit id="key.s">
-				<source><![CDATA[Key S]]></source>
 			</trans-unit>
 			<trans-unit id="key.s.mod">
 				<source><![CDATA[S]]></source>

--- a/Resources/Private/Language/locallang_video.xlf
+++ b/Resources/Private/Language/locallang_video.xlf
@@ -56,6 +56,9 @@
 			<trans-unit id="action.navigate.continuous-seek">
 				<source><![CDATA[Fast-forward ({trickPlayFactor}x)]]></source>
 			</trans-unit>
+			<trans-unit id="action.navigate.position.percental">
+				<source><![CDATA[Jump to position (%)]]></source>
+			</trans-unit>
 			<trans-unit id="action.playback.captions.toggle">
 				<source><![CDATA[Toggle captions]]></source>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_video.xlf
+++ b/Resources/Private/Language/locallang_video.xlf
@@ -176,6 +176,12 @@
 			<trans-unit id="key.s.mod">
 				<source><![CDATA[S]]></source>
 			</trans-unit>
+			<trans-unit id="key.unto">
+				<source><![CDATA[ to ]]></source>
+			</trans-unit>
+			<trans-unit id="key.unto.mod">
+				<source><![CDATA[-]]></source>
+			</trans-unit>
 			<trans-unit id="modal.bookmark.copy-link">
 				<source><![CDATA[Copy Link]]></source>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_video.xlf
+++ b/Resources/Private/Language/locallang_video.xlf
@@ -56,6 +56,9 @@
 			<trans-unit id="action.navigate.continuous-seek">
 				<source><![CDATA[Fast-forward ({trickPlayFactor}x)]]></source>
 			</trans-unit>
+			<trans-unit id="action.playback.captions.toggle">
+				<source><![CDATA[Toggle captions]]></source>
+			</trans-unit>
 			<trans-unit id="action.playback.toggle">
 				<source><![CDATA[Play / Pause]]></source>
 			</trans-unit>
@@ -145,6 +148,9 @@
 			</trans-unit>
 			<trans-unit id="key.b">
 				<source><![CDATA[Key B]]></source>
+			</trans-unit>
+			<trans-unit id="key.c">
+				<source><![CDATA[Key C]]></source>
 			</trans-unit>
 			<trans-unit id="key.f">
 				<source><![CDATA[Key F]]></source>


### PR DESCRIPTION
This PR adds the following keybindings:
- `c` to toggle captions
- `0`-`9` to jump to `0%` to `90%` of the video

These changes are not yet built. To try them out, run `npm run watch` in `Build/` folder.