### PR TITLE
Display paginated results only if there are some results

### DIFF
--- a/Resources/Private/Plugins/Kitodo/Templates/ListView/Main.html
+++ b/Resources/Private/Plugins/Kitodo/Templates/ListView/Main.html
@@ -22,9 +22,11 @@ Based on Kitodo.Presentation 4. Changes:
 
         <f:variable name="action" value="main" />
         <f:variable name="controller" value="ListView" />
-        <f:render partial="ListView/SortingForm" arguments="{_all}" />
 
-        <f:render partial="ListView/Results" arguments="{_all}" />
+        <f:if condition="{numResults} > 0">
+            <f:render partial="ListView/SortingForm" arguments="{_all}" />
+            <f:render partial="ListView/Results" arguments="{_all}" />
+        </f:if>
 
     </div>
 

--- a/Resources/Private/Plugins/Kitodo/Templates/Search/Main.html
+++ b/Resources/Private/Plugins/Kitodo/Templates/Search/Main.html
@@ -94,8 +94,10 @@ Based on Kitodo.Presentation 4. Changes:
         <f:render partial="ListView/SearchHits" arguments="{_all}" />
         <f:variable name="action" value="search" />
         <f:variable name="controller" value="Search" />
-        <f:render partial="ListView/SortingForm" arguments="{_all}" />
-        <f:render partial="ListView/Results" arguments="{_all}" />
+        <f:if condition="{numResults} > 0">
+            <f:render partial="ListView/SortingForm" arguments="{_all}" />
+            <f:render partial="ListView/Results" arguments="{_all}" />
+        </f:if>
     </div>
 
 </f:if>


### PR DESCRIPTION
Fix for `Core: Exception handler (WEB): Uncaught TYPO3 Exception: #1476107295: PHP Warning: A non-numeric value encountered in /var/www/html/vendor/typo3fluid/fluid/src/Core/Parser/SyntaxTree/Expression/MathExpressionNode.php line 77 `

Error is caused by `pagination` being null in expression `<f:variable name="currentPage" value="{pagination.currentPageNumber - 1}" />`. It is `null` when `numResults` is 0.

Related to https://github.com/kitodo/kitodo-presentation/pull/1148